### PR TITLE
Dockerfile 파일 내 의존성 관련 에러 해결 및 production 단계 최적화 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+**/node_modules
+**/.git
+**/.gitignore
+**/*.md
+**/dist

--- a/packages/backend/.dockerignore
+++ b/packages/backend/.dockerignore
@@ -1,5 +1,0 @@
-node_modules
-.git
-.gitignore
-*.md
-dist

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -7,28 +7,15 @@ COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY ./packages/backend ./packages/backend/
 COPY ./packages/shared ./packages/shared/
 
-RUN HUSKY=0 pnpm install --no-frozen-lockfile
+RUN HUSKY=0 pnpm install --frozen-lockfile
 
-COPY ./packages/backend ./packages/backend
-COPY ./packages/shared ./packages/shared
-COPY ./tsconfig.json ./
 RUN cd ./packages/backend && pnpm build
 
 FROM node:20-alpine AS production
 
 WORKDIR /app
 
-RUN npm install -g pnpm
-
-COPY --from=builder /app/package.json /app/pnpm-workspace.yaml ./
-COPY --from=builder /app/packages/backend/package.json ./packages/backend/
-COPY --from=builder /app/packages/shared/package.json ./packages/shared/
-
-RUN HUSKY=0 pnpm install --no-frozen-lockfile --prod --ignore-scripts
-
-COPY --from=builder /app/packages/backend/dist ./packages/backend/dist
-
-COPY --from=builder /app/packages/shared ./packages/shared
+COPY --from=builder /app .
 
 WORKDIR /app/packages/backend
 

--- a/packages/frontend/.dockerignore
+++ b/packages/frontend/.dockerignore
@@ -1,5 +1,0 @@
-node_modules
-.git
-.gitignore
-*.md
-dist


### PR DESCRIPTION
## ✏️ 한 줄 설명
> 이 PR의 주요 변경 사항이나 구현된 내용을 간략히 설명해 주세요.

빌드 시 간헐적으로 발생하는 의존성 관련 에러를 해결하기 위해 Dockerfile 명령어를 수정하였습니다.

## ✅ 작업 내용

Dockerfile의 `pnpm install --no-frozen-lockfile` 옵션은 `pnpm-lock.yaml` 파일이 현재 상태와 일치하지 않더라도 설치를 진행하도록 합니다. 이로 인해 빌드 환경과 로컬 환경 간의 의존성 버전 차이를 유발할 수 있다는 점을 발견했습니다.

이를 해결하기 위해 빌드 시 `pnpm install` 명령어에 `--frozen-lockfile` 옵션을 사용해서 `pnpm-lock.yaml` 파일과 일치하는 버전이 설치되도록 변경하였습니다.

그 밖에 프로덕션 빌드 시 `pnpm install`이 재실행되는 부분이 불필요하다고 판단하여 제거하고, `/app` 하위에 있는 파일들이 한번에 COPY되도록 명령어를 수정하는 등의 마이너한 수정 사항도 포함되어 있습니다.

### 💬 변경 사항 요약
- pnpm 빌드 과정에서 `pnpm install` 시 항상 lock 파일을 검사하도록 `--no-frozen-lockfile`을 `--frozen-lockfile` 옵션으로 변경
- 프로덕션 단계에서는 pnpm 빌드 단계에서 이미 설치한 의존성을 재사용하도록 변경

## 🏷️ 관련 이슈
(아직 없음)

## 📸 스크린샷/영상
> 백엔드 빌드 시 발생했던 에러 스크린샷을 참고용으로 첨부드립니다.

<img width="1203" alt="Screenshot 2025-01-10 at 1 31 27 PM" src="https://github.com/user-attachments/assets/926eba18-b7c7-4cb2-aa74-17e6266ed504" />


## 📌 리뷰 진행 시 참고 사항
> 리뷰 코멘트 작성 시 특정 사실에 대해 짚는 것이 아니라 코드에 대한 의견을 제안할 경우, 강도를 함께 제시해주세요! (1점: 가볍게 참고해봐도 좋을듯 ↔ 5점: 꼭 바꾸는 게 좋을 것 같음!)
- 기존에 production 단계에서 사용되었던 명령어의 대부분을 `COPY --from=builder /app .`으로 통합했습니다. 제 컴퓨터에서는 변경된 dockerfile로 빌드 및 컨테이너를 띄웠을 때 정상적으로 동작하긴 했지만, 다른 환경에서 테스트 시에도 문제 없이 동작하는지 확인이 필요합니다!